### PR TITLE
Remove arm64e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 TARGET := iphone:clang:latest:14.0
-ARCHS = arm64 arm64e
+ARCHS = arm64
 INSTALL_TARGET_PROCESSES = YouTube
 THEOS_PACKAGE_SCHEME = rootless
 FINALPACKAGE = 1


### PR DESCRIPTION
YouTube’s binary only uses arm64, so building in arm64e is useless.